### PR TITLE
Update removeCurrentRevisionMigrations.ts

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,7 +238,3 @@ won't update automatically. There are easy but important steps:
 4) Test the automatically created file's down function `sequelize db:migrate:undo`
 5) If there are any troubles, fix the auto-generated file (ordering!)
 6) Run `sequelize db:migrate:undo` and continue your amazing work
-
-## Documentation
-
-not ready yet.

--- a/src/utils/removeCurrentRevisionMigrations.ts
+++ b/src/utils/removeCurrentRevisionMigrations.ts
@@ -19,7 +19,7 @@ export default function removeCurrentRevisionMigrations(
       let i = 0;
       files.forEach(file => {
         i += 1;
-        if (file.split("-")[0] === revision.toString()) {
+        if (parseInt(file.split("-")[0]).toString() === revision.toString()) {
           fs.unlinkSync(`${migrationsPath}/${file}`);
           if (options.verbose) {
             console.log(`Successfully deleted ${file}`);


### PR DESCRIPTION
In this PR we are changing how to diff '0000002' from '2' and delete all files with the same revision.

Without this modification this will happen if my migration name is setted as a nonce:

![image](https://user-images.githubusercontent.com/6424940/112527752-258a0800-8d82-11eb-8027-228c61df7b76.png)